### PR TITLE
add `props.exportFrames`

### DIFF
--- a/src/events/keydown.ts
+++ b/src/events/keydown.ts
@@ -19,15 +19,7 @@ export default ({
     } else if ((ev.metaKey || ev.ctrlKey) && ev.shiftKey && ev.key === "s") {
       ev.preventDefault();
       // save frames (video)
-      if (!getGlobalState().savingFrames) {
-        updateGlobalState({
-          savingFrames: true,
-          frameRequested: true,
-          recordState: "start",
-        });
-      } else {
-        updateGlobalState({ recordState: "end" });
-      }
+      props.exportFrames();
     } else if ((ev.metaKey || ev.ctrlKey) && !ev.shiftKey && ev.key === "k") {
       if (import.meta.hot) {
         // git commit snapshot (image)

--- a/src/props.ts
+++ b/src/props.ts
@@ -18,7 +18,7 @@ import type {
   SketchStates,
   WebGLProps,
 } from "./types/types";
-import { updateGlobalState } from "./store";
+import { getGlobalState, updateGlobalState } from "./store";
 
 type CanvasProps = {
   canvas: HTMLCanvasElement;
@@ -47,7 +47,7 @@ export const createProps = ({
   ) as CanvasProps;
 
   // function props
-  const { exportFrame, togglePlay } = createFunctionProps({
+  const { exportFrame, exportFrames, togglePlay } = createFunctionProps({
     canvas,
     settings,
     states,
@@ -73,6 +73,7 @@ export const createProps = ({
     exportFps: settings.exportFps,
     recording: false,
     exportFrame,
+    exportFrames,
     togglePlay,
     render: renderProp,
     resize: resizeProp,
@@ -121,6 +122,7 @@ const createFunctionProps = ({
 }) => {
   return {
     exportFrame: createExportFrameProp({ canvas, settings, states }),
+    exportFrames: createExportFramesProp(),
     // update: createUpdateProp({
     //   canvas,
     //   settings,
@@ -149,6 +151,20 @@ const createExportFrameProp = ({
       settings,
       states,
     });
+  };
+};
+
+const createExportFramesProp = () => {
+  return () => {
+    if (!getGlobalState().savingFrames) {
+      updateGlobalState({
+        savingFrames: true,
+        frameRequested: true,
+        recordState: "start",
+      });
+    } else {
+      updateGlobalState({ recordState: "end" });
+    }
   };
 };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -200,8 +200,10 @@ export interface BaseProps {
   exportFps: number;
   /** true if recording in progress */
   recording: boolean;
-  /** call to export canvas as image */
+  /** export canvas as image */
   exportFrame: () => void;
+  /** Export canvas as frames or video in the format(s) specified in `settings.framesFormat`. Calling it again while recording will end the recording. */
+  exportFrames: () => void;
   /** call to play or pause sketch */
   togglePlay: () => void;
   /** call without any props for rendering-on-demand. it will call sketch's returned function. good for manually advancing animation frame-by-frame. */


### PR DESCRIPTION
Works the same ways as pressing CMD+SHFT+s to export video/frames. It allows exporting with a custom key when hotkeys are disabled. It may also be useful in situations where the keyboard is not available (ie. mobile)

Note that calling the function again while recording will finish the
current recording.
